### PR TITLE
fix: プロキシサーバーURLの正規化を追加

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -68,10 +68,11 @@ async function cycleTLSFetchWithProxy(
   let proxy: string | undefined
   const proxyServer = process.env.PROXY_SERVER
   if (proxyServer) {
-    // プロトコルがない場合は http:// を追加
-    const normalizedProxyServer = proxyServer.includes('://')
-      ? proxyServer
-      : `http://${proxyServer}`
+    // プロトコルがない場合、または HTTP(S) 以外の場合は http:// を追加
+    const normalizedProxyServer =
+      proxyServer.startsWith('http://') || proxyServer.startsWith('https://')
+        ? proxyServer
+        : `http://${proxyServer}`
 
     const proxyUsername = process.env.PROXY_USERNAME
     const proxyPassword = process.env.PROXY_PASSWORD
@@ -84,7 +85,7 @@ async function cycleTLSFetchWithProxy(
         proxy = proxyUrl.toString()
       } catch {
         throw new Error(
-          `Invalid PROXY_SERVER URL: ${proxyServer}. Expected format: host:port or http://host:port`,
+          `Invalid PROXY_SERVER URL: ${proxyServer}. Expected format: host:port, http://host:port or https://host:port`,
         )
       }
     } else {


### PR DESCRIPTION
## Summary
- `PROXY_SERVER` 環境変数にプロトコル (`http://`) が含まれていない場合に自動的に追加するように修正
- `host:port` 形式と `http://host:port` 形式の両方をサポート

## Background
GitHub Actions で `PROXY_SERVER=118.27.114.148:1234` のように設定されていたが、`new URL()` でパースする際にプロトコルがないため `Invalid URL` エラーが発生していた。

## Changes
- プロキシサーバーURLにプロトコルが含まれていない場合、`http://` を自動的に追加
- エラーメッセージを更新して、`host:port` 形式もサポートされることを明示

## Test plan
- [x] ローカルで `PROXY_SERVER=118.27.114.148:1234` 形式でテスト済み
- [x] `yarn build` で RSS 生成が正常に完了することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)