### PR TITLE
fix: 機密情報のログ出力リスクの修正

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -106,7 +106,7 @@ async function cycleTLSFetchWithProxy(
         proxy = proxyUrl.toString()
       } catch {
         throw new Error(
-          `Invalid PROXY_SERVER URL: ${proxyServer}. Expected format: host:port, http://host:port or https://host:port`,
+          'Invalid PROXY_SERVER URL. Expected format: host:port, http://host:port or https://host:port',
         )
       }
     } else {


### PR DESCRIPTION
## Summary

- プロキシサーバー URL のエラーメッセージから機密情報（`proxyServer` 変数の値）を削除しました
- これにより、無効なプロキシ URL が設定された場合でも、URL の内容がログに出力されなくなります

## 変更内容

`src/main.ts` の 109 行目において、エラーメッセージに含まれていた `${proxyServer}` の出力を削除しました。

### 変更前

```typescript
throw new Error(
  `Invalid PROXY_SERVER URL: ${proxyServer}. Expected format: host:port, http://host:port or https://host:port`,
)
```

### 変更後

```typescript
throw new Error(
  'Invalid PROXY_SERVER URL. Expected format: host:port, http://host:port or https://host:port',
)
```

## 関連 Issue

Closes #3201

## Test plan

- [x] Lint チェック（`yarn lint`）が成功すること
- [x] TypeScript コンパイル（`yarn compile:test`）が成功すること
- [x] エラーメッセージの変更のみのため、既存の動作に影響がないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)