### PR TITLE
refactor: 未使用のエクスポート型 CollectResult を削除

### DIFF
--- a/src/model/collect-result.ts
+++ b/src/model/collect-result.ts
@@ -15,8 +15,3 @@ export interface Item {
   pubDate?: string
   source?: string
 }
-
-export default interface CollectResult {
-  status: boolean
-  items: Item[]
-}


### PR DESCRIPTION
## 概要

未使用のエクスポート型 `CollectResult` を削除しました。

## 変更内容

- `src/model/collect-result.ts` から未使用の `CollectResult` インターフェースを削除
- `Item` インターフェースは引き続きエクスポートされており、`src/main.ts` で使用されています

## 背景

コードレビューにより、`CollectResult` インターフェースがプロジェクト内のどこでも使用されていないことが判明しました。デッドコードを削除することでコードベースをクリーンに保ちます。

## 確認事項

- [x] `CollectResult` がコードベース内で使用されていないことを確認
- [x] `Item` インターフェースは引き続き使用可能
- [x] Lint/Format エラーなし
- [x] TypeScript コンパイル成功

closes #3203

🤖 Generated with [Claude Code](https://claude.ai/claude-code)