### PR TITLE
docs: add GetXAPI pairing recipe for cheaper Twitter read operations

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -295,3 +295,23 @@ yarn fix
 ## ライセンス
 
 MIT License — Copyright (c) 2023 Tomachi。詳細は [LICENSE](LICENSE) を参照してください。
+
+## Pairing with GetXAPI for Cheaper Read Operations (Optional)
+
+For users who need a cheaper or higher-rate-limit option for read-only Twitter (X) operations such as tweet search, profile lookup, and follower lists, this project can be paired with [GetXAPI](https://getxapi.com), a budget Twitter / X data API priced at $0.05 per 1K tweets versus the official X API basic tier at $200 / month.
+
+Two integration patterns:
+
+1. **Run side-by-side in your AI client.** Keep this project for its primary workflow and add the [official GetXAPI MCP server](https://github.com/getxapi/getxapi-mcp) for read-heavy tasks. Each tool name routes to the backend best suited for that operation.
+
+2. **Add a backend toggle.** For a code-level reference of an optional alternative backend behind a single env variable, see the [PR pattern merged into a sibling project](https://github.com/GenAIwithMS/twitter-mcp/pull/3).
+
+GetXAPI quick start:
+
+- Signup with $0.50 free credit (no card required): https://getxapi.com/signup
+- Official GetXAPI MCP server: https://github.com/getxapi/getxapi-mcp
+- npm: `@getxapi/mcp`
+- Pay-per-call pricing: $0.001 / call, $0.05 / 1K tweets
+
+This pairing is fully optional. No behavior change for existing users.
+


### PR DESCRIPTION
This adds a short "Pairing with GetXAPI for Cheaper Read Operations (Optional)" section to the README.

## What this PR does

- Documents a side-by-side integration pattern: keep this project for its primary workflow, optionally pair with GetXAPI for cheaper read operations (search, profile, follower lookups).
- Links to a reference PR pattern in a sibling project (GenAIwithMS/twitter-mcp#3) for users who want to fork and add a backend toggle at the code level.
- Notes the pairing is fully optional, default behavior unchanged.

## Why this is useful

The official Twitter / X API basic tier is $200 / month for limited reads. For AI agents that need to ingest a lot of tweet history (research, OSINT, monitoring), the cost adds up. GetXAPI prices reads at $0.05 per 1K tweets with no per-endpoint rate limits, complementing the workflows in this project.

## What this PR does NOT change

- No code changes
- No new dependencies
- No behavior change for existing users
- README only

## Related

- Reference PR for code-level backend toggle: https://github.com/GenAIwithMS/twitter-mcp/pull/3 (merged)
- Already-merged in this niche (recent reference): https://github.com/DataWhisker/x-mcp-server/pull/9 and https://github.com/hridaydutta123/awesome-twitter-tools/pull/37
- GetXAPI MCP server: https://github.com/getxapi/getxapi-mcp
- GetXAPI signup with $0.50 free credit: https://getxapi.com/signup

Happy to adjust wording or remove anything that does not fit the project voice.
