### PR TITLE
fix: TypeScript v6 対応のため tsconfig.json のワークアラウンドを削除

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
     "target": "esnext",
     "moduleResolution": "Bundler",
     "lib": ["ESNext", "ESNext.AsyncIterable", "DOM"],
+    "types": ["node"],
     "outDir": "./dist",
     "rootDir": "./src",
     "removeComments": true,
@@ -21,8 +22,6 @@
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     "experimentalDecorators": true,
-    "ignoreDeprecations": "6.0",
-    "baseUrl": ".",
     "newLine": "LF",
     "paths": {
       "@/*": ["./src/*"]


### PR DESCRIPTION
## 概要

TypeScript v6.0 に正式対応するため、tsconfig.json の一時的なワークアラウンドを削除し、適切な設定へ移行します。

Fixes #3501

## 変更内容

- `ignoreDeprecations: "6.0"` を削除（TypeScript 7.0 では機能しなくなるため）
- `baseUrl: "."` を削除（`paths` が相対パス形式のため不要）
- `types: ["node"]` を追加（TypeScript 6.0 から `@types/node` の自動読み込みが廃止されたため）

## 動作確認

- `yarn compile` → TypeScript コンパイルエラーなし