### PR TITLE
fix: 非推奨の XMLBuilder を fast-xml-builder パッケージへ移行

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "eslint-plugin-import": "2.32.0",
     "eslint-plugin-n": "18.2.1",
     "eslint-plugin-promise": "7.3.0",
+    "fast-xml-builder": "1.3.0",
     "fast-xml-parser": "5.6.0",
     "headers-polyfill": "5.0.1",
     "prettier": "3.9.4",

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,6 @@
 import 'dotenv/config'
-import { XMLBuilder, XMLParser } from 'fast-xml-parser'
+import XMLBuilder from 'fast-xml-builder'
+import { XMLParser } from 'fast-xml-parser'
 import fs from 'node:fs'
 import { Item } from './model/collect-result'
 import { Logger } from '@book000/node-utils'

--- a/yarn.lock
+++ b/yarn.lock
@@ -1511,13 +1511,13 @@ fast-levenshtein@^2.0.6:
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==
 
-fast-xml-builder@^1.1.4:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/fast-xml-builder/-/fast-xml-builder-1.2.1.tgz#9a7e6eb76d794957a3e3b3d334ec4fcd92609803"
-  integrity sha512-tPb5TTWfgfVx5BNSi2xV0eLr89POeXXn0dXIsCJ9m1narrWxeIyx6je9d7Rce/3NyXLbvuQmLkxq+RuxMWejvw==
+fast-xml-builder@1.3.0, fast-xml-builder@^1.1.4:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/fast-xml-builder/-/fast-xml-builder-1.3.0.tgz#bc849804796fe47bf915022dd939b0fc30ba455d"
+  integrity sha512-F74cZEdCvuw9P41GAC3rod4X04jjWGM1JPEv/GWSqFTWLsdyMSBMBMlm9Hk3GLBgLBbdBNY8yee0pQh2RBVESQ==
   dependencies:
-    path-expression-matcher "^1.5.0"
-    xml-naming "^0.1.0"
+    path-expression-matcher "^1.6.2"
+    xml-naming "^0.3.0"
 
 fast-xml-parser@5.6.0:
   version "5.6.0"
@@ -2591,6 +2591,11 @@ path-expression-matcher@^1.5.0:
   resolved "https://registry.yarnpkg.com/path-expression-matcher/-/path-expression-matcher-1.6.1.tgz#fb190513954875d7e1b05c8caabe7fdd0a4cd75b"
   integrity sha512-h7bxdzhHk8Knyc4Tj+jMaa7fEEoUJy7p1qtbVgkYg1Uhpe5Np5VuGXCRZnkZvU+Q42M1vStt0ifa3ueykRJPmQ==
 
+path-expression-matcher@^1.6.2:
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/path-expression-matcher/-/path-expression-matcher-1.6.2.tgz#567c73c07197e9dcef24e90edcdc571056599168"
+  integrity sha512-enSlaiat05iasnzmgNxRj8reFdj3puY2QpNgP1aPIaVfT6nn9ICuPoFlKHk8EN22HcwewshO+mN2DGbkCEOtqQ==
+
 path-is-absolute@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
@@ -3610,10 +3615,10 @@ x-client-transaction-id@^0.2.0:
   dependencies:
     linkedom "^0.18.9"
 
-xml-naming@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/xml-naming/-/xml-naming-0.1.0.tgz#8ab7106c5b8d23caa2fabac1cadf17136379fbd8"
-  integrity sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==
+xml-naming@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/xml-naming/-/xml-naming-0.3.0.tgz#46c1e18bfe2858479982dd2accf34d16e749eda2"
+  integrity sha512-ghig2TBE/H11aOVgmahA3MhimvkBr6JIYknH/Dhdk10nXwdbIqBJsbfMxpvFPG8bAw77gN29aQWvKpmVoPlvPQ==
 
 xtend@^4.0.0:
   version "4.0.2"


### PR DESCRIPTION
## 概要

`fast-xml-parser` の `XMLBuilder` クラスは v5.7.1 以降で非推奨となっており（`@deprecated Use npm package 'fast-xml-builder' instead`）、Renovate PR #3404（`fast-xml-parser` 5.6.0 → 5.9.3 への更新）の CI で `@typescript-eslint/no-deprecated` により `src/main.ts` の `new XMLBuilder(...)` 呼び出しがエラーとして検出され、Node CI が失敗していました。

このPRでは、公式に案内されている移行先の `fast-xml-builder` パッケージへ `XMLBuilder` のインポート元を差し替えます。オプション（`ignoreAttributes`, `suppressBooleanAttributes`, `format`）と `.build()` メソッドのシグネチャは同一のため、挙動に変更はありません。

## 動作確認

- `fast-xml-parser` を 5.9.3 に一時的に上げた状態でも `yarn lint`（prettier / eslint / tsc）が通ることをローカルで確認済み。
- このPRでは `fast-xml-parser` 自体のバージョンは変更していません（バージョン更新は Renovate PR #3404 に任せます）。

Renovate PR: #3404