### PR TITLE
chore: .worktreeinclude を追加

### DIFF
--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,3 @@
+.env
+data/searches.json
+data/twitter-cookies.json


### PR DESCRIPTION
## 概要

`git worktree` 作成時にコピーしたいファイルを指定する `.worktreeinclude` を新規追加しました。

## 追加したパターン

- `.env`
- `data/searches.json`
- `data/twitter-cookies.json`

## 根拠（Phase 1 調査より）

- `.gitignore` に `.env`, `data/*`（`!data/searches.json` で例外あり）が含まれている。
- README.md: 「プロジェクトルートに `.env` ファイルを作成する（このファイルは `.gitignore` 対象）」との記載があり、`TWITTER_USERNAME`/`TWITTER_PASSWORD` 等の必須環境変数、`TWITTER_EMAIL_ADDRESS`/`TWITTER_AUTH_CODE_SECRET`/`PROXY_*` 等の任意環境変数を読み込む。
- `src/main.ts:1` で `import 'dotenv/config'` により `.env` を読み込み、`process.env.TWITTER_USERNAME` 等を直接参照している。
- `src/main.ts:193` で `COOKIE_CACHE_FILE = './data/twitter-cookies.json'` を定義し、ログインクッキーのキャッシュとして `fs.readFileSync`/`JSON.parse` で読み書きしている（`data/*` により gitignore 対象）。
- `docker-compose.yml` で `env_file: - .env` の指定と `./data:/data` のバインドマウントがある。
- `.env.example` 等のテンプレートファイルが存在しないため、`.worktreeinclude` による既存ファイルのコピーが特に有用。
- `data/searches.json` は `.gitignore` の `!data/searches.json` により実際には Git 管理下にあるため、コピー対象としては本来不要だが、Phase 1 調査時点の提案パターンに従い含めています。

## 関連

- https://github.com/book000/book000/issues/132
