### PR TITLE
fix: もよりの商店街の定期告知を除外

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules/
+.worktrees/
 dist/
 config/*
 !config/.gitkeep

--- a/data/searches.json
+++ b/data/searches.json
@@ -5,6 +5,6 @@
   "さんぽんた": "今日のさんぽんた from:rikirosso filter:images exclude:retweets",
   "がい子くじん": "from:gaiko_kujin filter:images exclude:retweets",
   "せかねこ": "from:sekaneko13 filter:images exclude:retweets",
-  "もよりの商店街": "from:twi_sirius もよりの商店街 filter:images exclude:retweets",
+  "もよりの商店街": "from:twi_sirius もよりの商店街 -毎週 filter:images exclude:retweets",
   "がんばってはたらく": "from:mozuku_zqu filter:images exclude:retweets"
 }

--- a/data/searches.json
+++ b/data/searches.json
@@ -5,6 +5,6 @@
   "さんぽんた": "今日のさんぽんた from:rikirosso filter:images exclude:retweets",
   "がい子くじん": "from:gaiko_kujin filter:images exclude:retweets",
   "せかねこ": "from:sekaneko13 filter:images exclude:retweets",
-  "もよりの商店街": "from:twi_sirius もよりの商店街 -毎週 filter:images exclude:retweets",
+  "もよりの商店街": "from:twi_sirius もよりの商店街 -\"毎週月・水・金曜日更新\" filter:images exclude:retweets",
   "がんばってはたらく": "from:mozuku_zqu filter:images exclude:retweets"
 }


### PR DESCRIPTION
## 概要

- `もよりの商店街` フィードで、既知の定期告知フレーズを検索段階で除外
- 隔離 worktree ディレクトリを Git 管理対象外に設定

## 検証

- `yarn compile`
- `yarn lint`
- ローカル差分レビュー（指摘なし）
- GitHub Actions の全 6 チェックが成功
- 実行確認は、ローカル Cookie の期限切れにより X が error 399 を返したため検索前に停止

## 現在の状態

- PR は競合なしでマージ可能
- Copilot レビュー依頼は利用可能でしたが、レビュアーとして設定されませんでした
- 自動監視はこのセッションに tmux pane がないため開始不可。`$resume-pr-monitor https://github.com/book000/twitter-rss/pull/3703` で再開可能